### PR TITLE
Fixed issue with running grype and syft

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = tab
+indent_size = 2

--- a/cmd/workflow-engine/cli/cli.go
+++ b/cmd/workflow-engine/cli/cli.go
@@ -278,7 +278,7 @@ func configBuiltins(cmd *cobra.Command) error {
 }
 
 func debugPipeline(cmd *cobra.Command, dryRun *bool) error {
-	pipeline := pipelines.NewDebug(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	pipeline := pipelines.NewDebug(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
 	pipeline.DryRunEnabled = *dryRun
 	return pipeline.Run()
 }
@@ -300,7 +300,7 @@ func imageBuildPipeline(cmd *cobra.Command, dryRun *bool, cliCmd imageBuildCmd, 
 }
 
 func imageScanPipeline(cmd *cobra.Command, dryRun *bool, config pipelines.ArtifactConfig, imageName string) error {
-	pipeline := pipelines.NewImageScan(cmd.OutOrStdout(), cmd.ErrOrStderr())
+	pipeline := pipelines.NewImageScan(cmd.InOrStdin(), cmd.OutOrStdout(), cmd.ErrOrStderr())
 	pipeline.DryRunEnabled = *dryRun
 
 	return pipeline.WithArtifactConfig(config).WithImageName(imageName).Run()

--- a/pkg/pipelines/debug.go
+++ b/pkg/pipelines/debug.go
@@ -10,14 +10,15 @@ import (
 )
 
 type Debug struct {
+	Stdin         io.Reader
 	Stdout        io.Writer
 	Stderr        io.Writer
 	DryRunEnabled bool
 }
 
 // NewDebug creates a new debug pipeline with custom stdout and stderr
-func NewDebug(stdoutW io.Writer, stderrW io.Writer) *Debug {
-	return &Debug{Stdout: stdoutW, Stderr: stderrW, DryRunEnabled: false}
+func NewDebug(stdinR io.Reader, stdoutW io.Writer, stderrW io.Writer) *Debug {
+	return &Debug{Stdin: stdinR, Stdout: stdoutW, Stderr: stderrW, DryRunEnabled: false}
 }
 
 // Run prints the version for all expected commands
@@ -39,8 +40,8 @@ func (d *Debug) Run() error {
 
 	// Collect errors for mandatory commands
 	errs := errors.Join(
-		shell.GrypeCommand(d.Stdout, d.Stderr).Version().WithDryRun(d.DryRunEnabled).Run(),
-		shell.SyftCommand(d.Stdout, d.Stderr).Version().WithDryRun(d.DryRunEnabled).Run(),
+		shell.GrypeCommand(d.Stdin, d.Stdout, d.Stderr).Version().WithDryRun(d.DryRunEnabled).Run(),
+		shell.SyftCommand(d.Stdin, d.Stdout, d.Stderr).Version().WithDryRun(d.DryRunEnabled).Run(),
 	)
 
 	// Just log errors for optional commands

--- a/pkg/shell/grype.go
+++ b/pkg/shell/grype.go
@@ -33,11 +33,12 @@ func (g *grypeCmd) ScanSBOM(filename string) *Command {
 	return NewCommand(exe)
 }
 
-// GrypeCommand with custom stdout and stderr
-func GrypeCommand(stdout io.Writer, stderr io.Writer) *grypeCmd {
+// GrypeCommand with custom stdin, stdout, and stderr
+// stdin must be provided even though it isn't used because without it grype exits immediately
+func GrypeCommand(stdin io.Reader, stdout io.Writer, stderr io.Writer) *grypeCmd {
 	return &grypeCmd{
 		InitCmd: func() *Executable {
-			return NewExecutable("grype").WithOutput(stdout).WithStderr(stderr)
+			return NewExecutable("grype").WithStdin(stdin).WithOutput(stdout).WithStderr(stderr)
 		},
 	}
 }

--- a/pkg/shell/syft.go
+++ b/pkg/shell/syft.go
@@ -23,11 +23,12 @@ func (s *syftCmd) ScanImage(image string) *Command {
 	return NewCommand(cmd)
 }
 
-// SyftCommand with custom stdout and stderr
-func SyftCommand(stdout io.Writer, stderr io.Writer) *syftCmd {
+// SyftCommand with custom stdin, stdout, and stderr
+// stdin must be provided even though it isn't used because without it syft exits immediately
+func SyftCommand(stdin io.Reader, stdout io.Writer, stderr io.Writer) *syftCmd {
 	return &syftCmd{
 		InitCmd: func() *Executable {
-			return NewExecutable("syft").WithOutput(stdout).WithStderr(stderr)
+			return NewExecutable("syft").WithStdin(stdin).WithOutput(stdout).WithStderr(stderr)
 		},
 	}
 }


### PR DESCRIPTION
Both and grype and syft exit without doing anything when they do not have any stdin attached. (tested running in docker with -it)