### PR TITLE
Config Refactor and Code Generation

### DIFF
--- a/.github/actions/code-scan/action.yml
+++ b/.github/actions/code-scan/action.yml
@@ -1,0 +1,34 @@
+name: Code Scan
+description: Scan a code repository with Workflow Engine
+inputs:
+  artifact_dir:
+    description: The target directory for all generated artifacts
+    default: artifacts
+  config_file:
+    description: The workflow engine config file name
+  gatecheck_bundle_filename:
+    description: The filename for the gatecheck bundle, a validatable archive of security artifacts
+    default: gatecheck-bundle.tar.gz
+  gitleaks_filename:
+    description: The filename for the gitleaks secret report - must contain 'gitleaks'
+    default: gitleaks-secrets-report.json
+  gitleaks_src_dir:
+    description: The target directory for the gitleaks scan
+    default: .
+  semgrep_filename:
+    description: The filename for the semgrep SAST report - must contain 'semgrep'
+    default: semgrep-sast-report.json
+  semgrep_rules:
+    description: Semgrep ruleset manual override
+    default: p/default
+runs:
+  using: docker
+  image: ghcr.io/cms-enterprise/batcave/workflow-engine:v0.0.1-rc.11
+  args: [run, code-scan, --config, '${{ inputs.config_file }}', --verbose]
+  env:
+    WFE_ARTIFACT_DIR: ${{ inputs.artifact_dir }}
+    WFE_CODE_SCAN_GITLEAKS_FILENAME: ${{ inputs.gitleaks_filename }}
+    WFE_CODE_SCAN_GITLEAKS_SRC_DIR: ${{ inputs.gitleaks_src_dir }}
+    WFE_CODE_SCAN_SEMGREP_FILENAME: ${{ inputs.semgrep_filename }}
+    WFE_CODE_SCAN_SEMGREP_RULES: ${{ inputs.semgrep_rules }}
+    WFE_GATECHECK_BUNDLE_FILENAME: ${{ inputs.gatecheck_bundle_filename }}

--- a/.github/actions/image-build-podman/action.yml
+++ b/.github/actions/image-build-podman/action.yml
@@ -1,40 +1,48 @@
-name: Build Image Podman
-description: Builds a Container Image using workflow-engine
-
+name: Build Image
+description: Build a container image with Workflow Engine
 inputs:
-  config_file:
-    description: The file location where the workflow-engine configuration is located
-    default: ""
-  build_dir:
-    description: The directory where the image build takes place.
-  dockerfile:
-    description: The name/path of the Dockerfile.
   args:
-    description: optional build arguments for the image build. Should be passed as comma seperated env values like "key1=value1,key2=value2"
-  tag:
-    description: The tag to be applied to the built image.
-  platform:
-    description: The platform for the image build.
-  target:
-    description: The target build stage in the Dockerfile.
-  cache_to:
-    description: Specifies where to store build cache.
+    description: Comma seperated list of build time variables
+  artifact_dir:
+    description: The target directory for all generated artifacts
+    default: artifacts
+  build_dir:
+    description: The build directory to using during an image build
+    default: .
   cache_from:
-    description: Specifies where to load build cache from.
+    description: External cache sources (e.g., "user/app:cache", "type=local,src=path/to/dir")
+  cache_to:
+    description: Cache export destinations (e.g., "user/app:cache", "type=local,src=path/to/dir")
+  config_file:
+    description: The workflow engine config file name
+  dockerfile:
+    description: The Dockerfile/Containerfile to use during an image build
+    default: Dockerfile
+  gatecheck_bundle_filename:
+    description: The filename for the gatecheck bundle, a validatable archive of security artifacts
+    default: gatecheck-bundle.tar.gz
+  image_tag:
+    description: The full image tag for the target container image
+    default: my-app:latest
+  platform:
+    description: The target platform for build
   squash_layers:
-    description: "Deprecated: use layers; When set to true, squashes the layers of the container image at the end of the build process."
-    default: "false"
-
+    description: squash image layers - Only Supported with Podman CLI
+  target:
+    description: The target build stage to build (e.g., [linux/amd64])
 runs:
   using: docker
-  image: "docker://ghcr.io/cms-enterprise/batcave/workflow-engine:podman-56dca66a"
-  args: [ "run", "image-build", "--config", "${{inputs.config_file}}", "-i", "podman" ]
+  image: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-v0.0.1-rc.11
+  args: [run, image-build, --cli-interface, podman, --config, '${{ inputs.config_file }}', --verbose]
   env:
-    WFE_IMAGE_BUILD_DIR: "${{inputs.build_dir}}"
-    WFE_IMAGE_BUILD_DOCKERFILE: "${{inputs.dockerfile}}"
-    WFE_IMAGE_BUILD_ARGS: "${{ inputs.args }}"
-    WFE_IMAGE_TAG: "${{inputs.tag}}"
-    WFE_BUILD_IMAGE_PLATFORM: "${{inputs.platform}}"
-    WFE_IMAGE_BUILD_TARGET: "${{inputs.target}}"
-    WFE_IMAGE_BUILD_CACHE_TO: "${{inputs.cache_to}}"
-    WFE_IMAGE_BUILD_CACHE_FROM: "${{inputs.cache_from}}"
+    WFE_ARTIFACT_DIR: ${{ inputs.artifact_dir }}
+    WFE_GATECHECK_BUNDLE_FILENAME: ${{ inputs.gatecheck_bundle_filename }}
+    WFE_IMAGE_BUILD_ARGS: ${{ inputs.args }}
+    WFE_IMAGE_BUILD_CACHE_FROM: ${{ inputs.cache_from }}
+    WFE_IMAGE_BUILD_CACHE_TO: ${{ inputs.cache_to }}
+    WFE_IMAGE_BUILD_DIR: ${{ inputs.build_dir }}
+    WFE_IMAGE_BUILD_DOCKERFILE: ${{ inputs.dockerfile }}
+    WFE_IMAGE_BUILD_PLATFORM: ${{ inputs.platform }}
+    WFE_IMAGE_BUILD_SQUASH_LAYERS: ${{ inputs.squash_layers }}
+    WFE_IMAGE_BUILD_TARGET: ${{ inputs.target }}
+    WFE_IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/actions/image-build/action.yml
+++ b/.github/actions/image-build/action.yml
@@ -1,40 +1,48 @@
 name: Build Image
-description: Builds a Container Image using workflow-engine
-
+description: Build a container image with Workflow Engine
 inputs:
-  config_file:
-    description: The file location where the workflow-engine configuration is located
-    default: ""
-  build_dir:
-    description: The directory where the image build takes place.
-  dockerfile:
-    description: The name/path of the Dockerfile.
   args:
-    description: optional build arguments for the image build. Should be passed as comma seperated env values like "key1=value1,key2=value2"
-  tag:
-    description: The tag to be applied to the built image.
-  platform:
-    description: The platform for the image build.
-  target:
-    description: The target build stage in the Dockerfile.
-  cache_to:
-    description: Specifies where to store build cache.
+    description: Comma seperated list of build time variables
+  artifact_dir:
+    description: The target directory for all generated artifacts
+    default: artifacts
+  build_dir:
+    description: The build directory to using during an image build
+    default: .
   cache_from:
-    description: Specifies where to load build cache from.
+    description: External cache sources (e.g., "user/app:cache", "type=local,src=path/to/dir")
+  cache_to:
+    description: Cache export destinations (e.g., "user/app:cache", "type=local,src=path/to/dir")
+  config_file:
+    description: The workflow engine config file name
+  dockerfile:
+    description: The Dockerfile/Containerfile to use during an image build
+    default: Dockerfile
+  gatecheck_bundle_filename:
+    description: The filename for the gatecheck bundle, a validatable archive of security artifacts
+    default: gatecheck-bundle.tar.gz
+  image_tag:
+    description: The full image tag for the target container image
+    default: my-app:latest
+  platform:
+    description: The target platform for build
   squash_layers:
-    description: "Deprecated: use layers; When set to true, squashes the layers of the container image at the end of the build process."
-    default: "false"
-
+    description: squash image layers - Only Supported with Podman CLI
+  target:
+    description: The target build stage to build (e.g., [linux/amd64])
 runs:
   using: docker
-  image: "docker://ghcr.io/cms-enterprise/batcave/workflow-engine:56dca66a"
-  args: [ "run", "image-build", "--config", "${{inputs.config_file}}", "--verbose" ]
+  image: ghcr.io/cms-enterprise/batcave/workflow-engine:v0.0.1-rc.11
+  args: [run, image-build, --cli-interface, docker, --config, '${{ inputs.config_file }}', --verbose]
   env:
-    WFE_IMAGE_BUILD_DIR: "${{inputs.build_dir}}"
-    WFE_IMAGE_BUILD_DOCKERFILE: "${{inputs.dockerfile}}"
-    WFE_IMAGE_BUILD_ARGS: "${{ inputs.args }}"
-    WFE_IMAGE_TAG: "${{inputs.tag}}"
-    WFE_BUILD_IMAGE_PLATFORM: "${{inputs.platform}}"
-    WFE_IMAGE_BUILD_TARGET: "${{inputs.target}}"
-    WFE_IMAGE_BUILD_CACHE_TO: "${{inputs.cache_to}}"
-    WFE_IMAGE_BUILD_CACHE_FROM: "${{inputs.cache_from}}"
+    WFE_ARTIFACT_DIR: ${{ inputs.artifact_dir }}
+    WFE_GATECHECK_BUNDLE_FILENAME: ${{ inputs.gatecheck_bundle_filename }}
+    WFE_IMAGE_BUILD_ARGS: ${{ inputs.args }}
+    WFE_IMAGE_BUILD_CACHE_FROM: ${{ inputs.cache_from }}
+    WFE_IMAGE_BUILD_CACHE_TO: ${{ inputs.cache_to }}
+    WFE_IMAGE_BUILD_DIR: ${{ inputs.build_dir }}
+    WFE_IMAGE_BUILD_DOCKERFILE: ${{ inputs.dockerfile }}
+    WFE_IMAGE_BUILD_PLATFORM: ${{ inputs.platform }}
+    WFE_IMAGE_BUILD_SQUASH_LAYERS: ${{ inputs.squash_layers }}
+    WFE_IMAGE_BUILD_TARGET: ${{ inputs.target }}
+    WFE_IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/actions/image-publish-podman/action.yml
+++ b/.github/actions/image-publish-podman/action.yml
@@ -1,0 +1,21 @@
+name: Image Publish
+description: Publish a container image with Workflow Engine
+inputs:
+  bundle_publish_enabled:
+    description: Enable/Disable gatecheck artifact bundle publish task
+  bundle_tag:
+    description: The full image tag for the target gatecheck bundle image blob
+    default: my-app/artifact-bundle:latest
+  config_file:
+    description: The workflow engine config file name
+  image_tag:
+    description: The full image tag for the target container image
+    default: my-app:latest
+runs:
+  using: docker
+  image: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-v0.0.1-rc.11
+  args: [run, image-publish, --cli-interface, podman, --config, '${{ inputs.config_file }}', --verbose]
+  env:
+    WFE_IMAGE_BUNDLE_PUBLISH_ENABLED: ${{ inputs.bundle_publish_enabled }}
+    WFE_IMAGE_PUBLISH_BUNDLE_TAG: ${{ inputs.bundle_tag }}
+    WFE_IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/actions/image-publish/action.yml
+++ b/.github/actions/image-publish/action.yml
@@ -1,0 +1,21 @@
+name: Image Publish
+description: Publish a container image with Workflow Engine
+inputs:
+  bundle_publish_enabled:
+    description: Enable/Disable gatecheck artifact bundle publish task
+  bundle_tag:
+    description: The full image tag for the target gatecheck bundle image blob
+    default: my-app/artifact-bundle:latest
+  config_file:
+    description: The workflow engine config file name
+  image_tag:
+    description: The full image tag for the target container image
+    default: my-app:latest
+runs:
+  using: docker
+  image: ghcr.io/cms-enterprise/batcave/workflow-engine:v0.0.1-rc.11
+  args: [run, image-publish, --cli-interface, docker, --config, '${{ inputs.config_file }}', --verbose]
+  env:
+    WFE_IMAGE_BUNDLE_PUBLISH_ENABLED: ${{ inputs.bundle_publish_enabled }}
+    WFE_IMAGE_PUBLISH_BUNDLE_TAG: ${{ inputs.bundle_tag }}
+    WFE_IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/actions/image-scan-podman/action.yml
+++ b/.github/actions/image-scan-podman/action.yml
@@ -1,34 +1,37 @@
-name: Scan Image Podman
-description: Scans a Container Image using workflow-engine
-
+name: Image Scan
+description: Scan a container image with Workflow Engine
 inputs:
-  config_file:
-    description: "The file location where the workflow-engine configuration is located"
-    default: ""
-  tag:
-    description: "The target for image scanning."
-  clamav_filename:
-    description: "Filename for ClamAV scan report."
-  syft_filename:
-    description: "Filename for Syft SBOM report."
-  grype_config_filename:
-    description: "Configuration file for Grype."
-  grype_active_findings_filename:
-    description: "Filename for Grype active findings report."
-  grype_all_findings_filename:
-    description: "Filename for Grype full findings report."
   artifact_dir:
-    description: "The directory where image scan artifacts should be stored"
-
+    description: The target directory for all generated artifacts
+    default: artifacts
+  clamav_filename:
+    description: The filename for the clamscan virus report - must contain 'clamav'
+    default: clamav-virus-report.txt
+  config_file:
+    description: The workflow engine config file name
+  gatecheck_bundle_filename:
+    description: The filename for the gatecheck bundle, a validatable archive of security artifacts
+    default: gatecheck-bundle.tar.gz
+  grype_config_filename:
+    description: The config filename for the grype vulnerability report
+  grype_filename:
+    description: The filename for the grype vulnerability report - must contain 'grype'
+    default: grype-vulnerability-report-full.json
+  image_tag:
+    description: The full image tag for the target container image
+    default: my-app:latest
+  syft_filename:
+    description: The filename for the syft SBOM report - must contain 'syft'
+    default: syft-sbom-report.json
 runs:
   using: docker
-  image: "docker://ghcr.io/cms-enterprise/batcave/workflow-engine:podman-56dca66a"
-  args: [ "run", "image-scan", "--config", "${{inputs.config_file}}", "-i", "podman" ]
+  image: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-v0.0.1-rc.11
+  args: [run, image-scan, --cli-interface, podman, --config, '${{ inputs.config_file }}', --verbose]
   env:
-    WFE_IMAGE_TAG: "${{inputs.tag}}"
-    WFE_IMAGE_SCAN_CLAMAV_FILENAME: "${{inputs.clamav_filename}}"
-    WFE_IMAGE_SCAN_SYFT_FILENAME: "${{inputs.syft_filename}}"
-    WFE_IMAGE_SCAN_GRYPE_CONFIG_FILENAME: "${{inputs.grype_config_filename}}"
-    WFE_IMAGE_SCAN_GRYPE_ACTIVE_FINDINGS_FILENAME: "${{inputs.grype_active_findings_filename}}"
-    WFE_IMAGE_SCAN_GRYPE_ALL_FINDINGS_FILENAME: "${{inputs.grype_all_findings_filename}}"
-    WFE_ARTIFACT_DIR: "${{inputs.artifact_dir}}"
+    WFE_ARTIFACT_DIR: ${{ inputs.artifact_dir }}
+    WFE_GATECHECK_BUNDLE_FILENAME: ${{ inputs.gatecheck_bundle_filename }}
+    WFE_IMAGE_SCAN_CLAMAV_FILENAME: ${{ inputs.clamav_filename }}
+    WFE_IMAGE_SCAN_GRYPE_CONFIG_FILENAME: ${{ inputs.grype_config_filename }}
+    WFE_IMAGE_SCAN_GRYPE_FILENAME: ${{ inputs.grype_filename }}
+    WFE_IMAGE_SCAN_SYFT_FILENAME: ${{ inputs.syft_filename }}
+    WFE_IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/actions/image-scan/action.yml
+++ b/.github/actions/image-scan/action.yml
@@ -1,35 +1,37 @@
-name: Scan Image
-description: Scans a Container Image using workflow-engine
-
+name: Image Scan
+description: Scan a container image with Workflow Engine
 inputs:
-  config_file:
-    description: "The file location where the workflow-engine configuration is located"
-    default: ""
-  tag:
-    description: "The target for image scanning."
-  clamav_filename:
-    description: "Filename for ClamAV scan report."
-  syft_filename:
-    description: "Filename for Syft SBOM report."
-  grype_config_filename:
-    description: "Configuration file for Grype."
-  grype_active_findings_filename:
-    description: "Filename for Grype active findings report."
-  grype_all_findings_filename:
-    description: "Filename for Grype full findings report."
   artifact_dir:
-    description: "The directory where image scan artifacts should be stored"
-
+    description: The target directory for all generated artifacts
+    default: artifacts
+  clamav_filename:
+    description: The filename for the clamscan virus report - must contain 'clamav'
+    default: clamav-virus-report.txt
+  config_file:
+    description: The workflow engine config file name
+  gatecheck_bundle_filename:
+    description: The filename for the gatecheck bundle, a validatable archive of security artifacts
+    default: gatecheck-bundle.tar.gz
+  grype_config_filename:
+    description: The config filename for the grype vulnerability report
+  grype_filename:
+    description: The filename for the grype vulnerability report - must contain 'grype'
+    default: grype-vulnerability-report-full.json
+  image_tag:
+    description: The full image tag for the target container image
+    default: my-app:latest
+  syft_filename:
+    description: The filename for the syft SBOM report - must contain 'syft'
+    default: syft-sbom-report.json
 runs:
   using: docker
-  image: "docker://ghcr.io/cms-enterprise/batcave/workflow-engine:56dca66a"
-  args: [ "run", "image-scan", "--config", "${{inputs.config_file}}", "--verbose" ]
+  image: ghcr.io/cms-enterprise/batcave/workflow-engine:v0.0.1-rc.11
+  args: [run, image-scan, --cli-interface, docker, --config, '${{ inputs.config_file }}', --verbose]
   env:
-    WFE_IMAGE_TAG: "${{inputs.tag}}"
-    WFE_IMAGE_SCAN_CLAMAV_FILENAME: "${{inputs.clamav_filename}}"
-    WFE_IMAGE_SCAN_SYFT_FILENAME: "${{inputs.syft_filename}}"
-    WFE_IMAGE_SCAN_GRYPE_CONFIG_FILENAME: "${{inputs.grype_config_filename}}"
-    WFE_IMAGE_SCAN_GRYPE_ACTIVE_FINDINGS_FILENAME: "${{inputs.grype_active_findings_filename}}"
-    WFE_IMAGE_SCAN_GRYPE_ALL_FINDINGS_FILENAME: "${{inputs.grype_all_findings_filename}}"
-    WFE_ARTIFACT_DIR: "${{inputs.artifact_dir}}"
-
+    WFE_ARTIFACT_DIR: ${{ inputs.artifact_dir }}
+    WFE_GATECHECK_BUNDLE_FILENAME: ${{ inputs.gatecheck_bundle_filename }}
+    WFE_IMAGE_SCAN_CLAMAV_FILENAME: ${{ inputs.clamav_filename }}
+    WFE_IMAGE_SCAN_GRYPE_CONFIG_FILENAME: ${{ inputs.grype_config_filename }}
+    WFE_IMAGE_SCAN_GRYPE_FILENAME: ${{ inputs.grype_filename }}
+    WFE_IMAGE_SCAN_SYFT_FILENAME: ${{ inputs.syft_filename }}
+    WFE_IMAGE_TAG: ${{ inputs.image_tag }}

--- a/.github/workflows/delivery.yaml
+++ b/.github/workflows/delivery.yaml
@@ -18,17 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # In order to support caching we need to make sure we are using the docker-container driver for builds
-      # - name: Restore image layer cache
-      #   uses: actions/cache/restore@v4
-      #   with:
-      #     path: ./container-cache-in
-      #     key: ${{ runner.os }}-
-      #     restore-keys: |
-      #       layers-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('Dockerfile') }}
-      #       layers-${{ runner.os }}-${{ github.ref }}
-      #       layers-${{ runner.os }}
-
       - name: Set outputs
         id: vars
         run: |
@@ -36,41 +25,34 @@ jobs:
           if [[ $GITHUB_REF == refs/tags/v* ]]; then
             echo "tag_name=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
           fi
-          echo "VERSION=$(git describe --tags)" >> $GITHUB_ENV
-          echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_ENV
-          echo "GIT_DESCRIPTION=$(git log -1 --pretty=%B | head -n 1)" >> $GITHUB_ENV
+          echo "VERSION=$(git describe --tags)" >> $GITHUB_OUTPUT
+          echo "GIT_COMMIT=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          echo "GIT_DESCRIPTION=$(git log -1 --pretty=%B | head -n 1)" >> $GITHUB_OUTPUT
 
       # TODO combine all delivery jobs into a single action
       - name: Build container image
         uses: ./.github/actions/image-build
         with:
-          tag: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ steps.vars.outputs.tag_name }}
-          # cache_from: ./container-cache-in
-          # cache_to: ./container-cache-out
-          args: "VERSION=${{ env.VERSION }},GIT_COMMIT=${{ env.GIT_COMMIT }},GIT_DESCRIPTION=${{ env.GIT_DESCRIPTION }}"
-
-      # - name: Save image layer cache
-      #   uses: actions/cache/save@v4
-      #   with:
-      #     path: ./container-cache-out
-      #     key: layers-${{ runner.os }}-${{ github.ref }}-${{ hashFiles('Dockerfile') }}
+          image_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ steps.vars.outputs.tag_name }}
+          args: "VERSION=${{ steps.vars.outputs.VERSION }},GIT_COMMIT=${{ steps.vars.outputs.GIT_COMMIT }},GIT_DESCRIPTION=${{ steps.vars.outputs.GIT_DESCRIPTION }}"
 
       - name: Build podman container image
         uses: ./.github/actions/image-build
         with:
           target: workflow-engine-podman
-          tag: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-${{ steps.vars.outputs.tag_name }}
+          image_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-${{ steps.vars.outputs.tag_name }}
+          args: "VERSION=${{ steps.vars.outputs.VERSION }},GIT_COMMIT=${{ steps.vars.outputs.GIT_COMMIT }},GIT_DESCRIPTION=${{ steps.vars.outputs.GIT_DESCRIPTION }}"
 
       - name: Scan container image
         uses: ./.github/actions/image-scan
         with:
-          tag: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ steps.vars.outputs.tag_name }}
+          image_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ steps.vars.outputs.tag_name }}
           artifact_dir: ./artifacts
 
       - name: Scan podman container image
         uses: ./.github/actions/image-scan
         with:
-          tag: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-${{ steps.vars.outputs.tag_name }}
+          image_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-${{ steps.vars.outputs.tag_name }}
           artifact_dir: ./artifacts/podman
 
       - uses: docker/login-action@v3
@@ -79,16 +61,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # TODO: this should be something workflow-engine does as apart of the delivery pipeline
-      - name: Push image
-        # TODO: in the future push based on protected git tags
-        # if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        shell: bash
-        run: docker push ghcr.io/cms-enterprise/batcave/workflow-engine:${{ steps.vars.outputs.tag_name }}
+      - name: Publish container image
+        uses: ./.github/actions/image-publish
+        with:
+          image_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ steps.vars.outputs.tag_name }}
+          bundle_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ steps.vars.outputs.tag_name }}-bundle
 
-      - name: Push podman image
-        shell: bash
-        run: docker push ghcr.io/cms-enterprise/batcave/workflow-engine:podman-${{ steps.vars.outputs.tag_name }}
+      - name: Publish podman container image
+        uses: ./.github/actions/image-publish
+        with:
+          image_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-${{ steps.vars.outputs.tag_name }}
+          bundle_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-${{ steps.vars.outputs.tag_name }}-bundle
 
       - name: job summary
         shell: bash

--- a/.github/workflows/delivery.yaml
+++ b/.github/workflows/delivery.yaml
@@ -61,17 +61,25 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish container image
-        uses: ./.github/actions/image-publish
-        with:
-          image_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ steps.vars.outputs.tag_name }}
-          bundle_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ steps.vars.outputs.tag_name }}-bundle
+      - name: Push image
+        shell: bash
+        run: docker push ghcr.io/cms-enterprise/batcave/workflow-engine:${{ steps.vars.outputs.tag_name }}
 
-      - name: Publish podman container image
-        uses: ./.github/actions/image-publish
-        with:
-          image_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-${{ steps.vars.outputs.tag_name }}
-          bundle_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-${{ steps.vars.outputs.tag_name }}-bundle
+      - name: Push podman image
+        shell: bash
+        run: docker push ghcr.io/cms-enterprise/batcave/workflow-engine:podman-${{ steps.vars.outputs.tag_name }}
+      # TODO: figure out Login Authentication inside of a container
+      # - name: Publish container image
+      #   uses: ./.github/actions/image-publish
+      #   with:
+      #     image_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ steps.vars.outputs.tag_name }}
+      #     bundle_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:${{ steps.vars.outputs.tag_name }}-bundle
+
+      # - name: Publish podman container image
+      #   uses: ./.github/actions/image-publish
+      #   with:
+      #     image_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-${{ steps.vars.outputs.tag_name }}
+      #     bundle_tag: ghcr.io/cms-enterprise/batcave/workflow-engine:podman-${{ steps.vars.outputs.tag_name }}-bundle
 
       - name: job summary
         shell: bash

--- a/README.md
+++ b/README.md
@@ -68,34 +68,34 @@ Configuration Order-of-Precedence:
 
 Note: `(none)` means unset, left blank
 
-<!---
-TODO: update environment variables table
+| Config Key                        | Environment Variable                 | Default Value                        | Description                                                                        |
+| --------------------------------- | ------------------------------------ | ------------------------------------ | ---------------------------------------------------------------------------------- |
+| codescan.enabled                  | WFE_CODE_SCAN_ENABLED                | 1                                    | Enable/Disable the code scan pipeline                                              |
+| codescan.gitleaksfilename         | WFE_CODE_SCAN_GITLEAKS_FILENAME      | gitleaks-secrets-report.json         | The filename for the gitleaks secret report - must contain 'gitleaks'              |
+| codescan.gitleakssrcdir           | WFE_CODE_SCAN_GITLEAKS_SRC_DIR       | .                                    | The target directory for the gitleaks scan                                         |
+| codescan.semgrepfilename          | WFE_CODE_SCAN_SEMGREP_FILENAME       | semgrep-sast-report.json             | The filename for the semgrep SAST report - must contain 'semgrep'                  |
+| codescan.semgreprules             | WFE_CODE_SCAN_SEMGREP_RULES          | p/default                            | Semgrep ruleset manual override                                                    |
+| deploy.enabled                    | WFE_IMAGE_PUBLISH_ENABLED            | 1                                    | Enable/Disable the deploy pipeline                                                 |
+| deploy.gatecheckconfigfilename    | WFE_DEPLOY_GATECHECK_CONFIG_FILENAME | -                                    | The filename for the gatecheck config                                              |
+| gatecheckbundlefilename           | WFE_GATECHECK_BUNDLE_FILENAME        | artifacts/gatecheck-bundle.tar.gz    | The filename for the gatecheck bundle, a validatable archive of security artifacts |
+| imagebuild.args                   | WFE_IMAGE_BUILD_ARGS                 | -                                    | Comma seperated list of build time variables                                       |
+| imagebuild.builddir               | WFE_IMAGE_BUILD_DIR                  | .                                    | The build directory to using during an image build                                 |
+| imagebuild.cachefrom              | WFE_IMAGE_BUILD_CACHE_FROM           | -                                    | External cache sources (e.g., "user/app:cache", "type=local,src=path/to/dir")      |
+| imagebuild.cacheto                | WFE_IMAGE_BUILD_CACHE_TO             | -                                    | Cache export destinations (e.g., "user/app:cache", "type=local,src=path/to/dir")   |
+| imagebuild.dockerfile             | WFE_IMAGE_BUILD_DOCKERFILE           | Dockerfile                           | The Dockerfile/Containerfile to use during an image build                          |
+| imagebuild.enabled                | WFE_IMAGE_BUILD_ENABLED              | 1                                    | Enable/Disable the image build pipeline                                            |
+| imagebuild.platform               | WFE_IMAGE_BUILD_PLATFORM             | -                                    | The target platform for build                                                      |
+| imagebuild.squashlayers           | WFE_IMAGE_BUILD_SQUASH_LAYERS        | 0                                    | squash image layers - Only Supported with Podman CLI                               |
+| imagebuild.target                 | WFE_IMAGE_BUILD_TARGET               | -                                    | The target build stage to build (e.g., [linux/amd64])                              |
+| imagepublish.bundlepublishenabled | WFE_IMAGE_BUNDLE_PUBLISH_ENABLED     | 1                                    | Enable/Disable gatecheck artifact bundle publish task                              |
+| imagepublish.bundletag            | WFE_IMAGE_PUBLISH_BUNDLE_TAG         | my-app/artifact-bundle:latest        | The full image tag for the target gatecheck bundle image blob                      |
+| imagepublish.enabled              | WFE_IMAGE_PUBLISH_ENABLED            | 1                                    | Enable/Disable the image publish pipeline                                          |
+| imagescan.clamavFilename          | WFE_IMAGE_SCAN_CLAMAV_FILENAME       | clamav-virus-report.txt              | The filename for the clamscan virus report - must contain 'clamav'                 |
+| imagescan.enabled                 | WFE_IMAGE_SCAN_ENABLED               | 1                                    | Enable/Disable the image scan pipeline                                             |
+| imagescan.grypeconfigfilename     | WFE_IMAGE_SCAN_GRYPE_CONFIG_FILENAME | -                                    | The config filename for the grype vulnerability report                             |
+| imagescan.grypefilename           | WFE_IMAGE_SCAN_GRYPE_FILENAME        | grype-vulnerability-report-full.json | The filename for the grype vulnerability report - must contain 'grype'             |
+| imagescan.syftfilename            | WFE_IMAGE_SCAN_SYFT_FILENAME         | syft-sbom-report.json                | The filename for the syft SBOM report - must contain 'syft'                        |
 
-| Env Variable                                  | Viper Key                             | Default Value                            | Description                                      |
-| --------------------------------------------- | ------------------------------------- | ---------------------------------------- | ------------------------------------------------ |
-| WFE_IMAGE_BUILD_ENABLED                       | imagebuild.enabled                    | 1                                        | Enables or disables the image build process.     |
-| WFE_IMAGE_BUILD_DIR                           | imagebuild.builddir                   | "."                                      | The directory where the image build takes place. |
-| WFE_IMAGE_BUILD_DOCKERFILE                    | imagebuild.dockerfile                 | "Dockerfile"                             | The name/path of the Dockerfile.                 |
-| WFE_IMAGE_BUILD_TAG                           | imagebuild.tag                        | (none)                                   | The tag to be applied to the built image.        |
-| WFE_BUILD_IMAGE_PLATFORM                      | imagebuild.platform                   | (none)                                   | The platform for the image build.                |
-| WFE_IMAGE_BUILD_TARGET                        | imagebuild.target                     | (none)                                   | The target build stage in the Dockerfile.        |
-| WFE_IMAGE_BUILD_CACHE_TO                      | imagebuild.cacheto                    | (none)                                   | Specifies where to store build cache.            |
-| WFE_IMAGE_BUILD_CACHE_FROM                    | imagebuild.cachefrom                  | (none)                                   | Specifies where to load build cache from.        |
-| WFE_IMAGE_BUILD_SQUASH_LAYERS                 | imagebuild.squashlayers               | (none)                                   | Enable or disable squashing of build layers.     |
-| WFE_IMAGE_BUILD_SCAN_TARGET                   | imagebuild.scantarget                 | (none)                                   | The target for image scanning.                   |
-| WFE_IMAGE_SCAN_ENABLED                        | imagescan.enabled                     | 1                                        | Enables or disables the image scanning process.  |
-| WFE_IMAGE_SCAN_CLAMAV_FILENAME                | imagescan.clamavFilename              | "clamav-virus-report.txt"                | Filename for ClamAV scan report.                 |
-| WFE_IMAGE_SCAN_SYFT_FILENAME                  | imagescan.syftFilename                | "syft-sbom-report.json"                  | Filename for Syft SBOM report.                   |
-| WFE_IMAGE_SCAN_GRYPE_CONFIG_FILENAME          | imagescan.grypeConfigFilename         | (none)                                   | Configuration file for Grype.                    |
-| WFE_IMAGE_SCAN_GRYPE_ACTIVE_FINDINGS_FILENAME | imagescan.grypeActiveFindingsFilename | "grype-vulnerability-report-active.json" | Filename for Grype active findings report.       |
-| WFE_IMAGE_SCAN_GRYPE_ALL_FINDINGS_FILENAME    | imagescan.grypeAllFindingsFilename    | "grype-vulnerability-report-full.json"   | Filename for Grype full findings report.         |
-| WFE_CODE_SCAN_ENABLED                         | codescan.enabled                      | 1                                        | Enables or disables the code scanning process.   |
-| WFE_CODE_SCAN_GITLEAKS_FILENAME               | codescan.gitleaksFilename             | "gitleaks-secrets-report.json"           | Filename for Gitleaks secrets report.            |
-| WFE_CODE_SCAN_GITLEAKS_SRC_DIR                | codescan.gitleaksSrcDir               | "."                                      | Source directory for Gitleaks scan.              |
-| WFE_CODE_SCAN_SEMGREP_FILENAME                | codescan.semgrepFilename              | "semgrep-sast-report.json"               | Filename for Semgrep SAST report.                |
-| WFE_CODE_SCAN_SEMGREP_RULES                   | codescan.semgrepRules                 | "p/default"                              | Rule set for Semgrep scan.                       |
-
---->
 ## Running in Docker
 
 When running workflow-engine in a docker container there are some pipelines that need to run docker commands.

--- a/README.md
+++ b/README.md
@@ -90,11 +90,12 @@ Note: `(none)` means unset, left blank
 | imagepublish.bundlepublishenabled | WFE_IMAGE_BUNDLE_PUBLISH_ENABLED     | 1                                    | Enable/Disable gatecheck artifact bundle publish task                              |
 | imagepublish.bundletag            | WFE_IMAGE_PUBLISH_BUNDLE_TAG         | my-app/artifact-bundle:latest        | The full image tag for the target gatecheck bundle image blob                      |
 | imagepublish.enabled              | WFE_IMAGE_PUBLISH_ENABLED            | 1                                    | Enable/Disable the image publish pipeline                                          |
-| imagescan.clamavFilename          | WFE_IMAGE_SCAN_CLAMAV_FILENAME       | clamav-virus-report.txt              | The filename for the clamscan virus report - must contain 'clamav'                 |
+| imagescan.clamavfilename          | WFE_IMAGE_SCAN_CLAMAV_FILENAME       | clamav-virus-report.txt              | The filename for the clamscan virus report - must contain 'clamav'                 |
 | imagescan.enabled                 | WFE_IMAGE_SCAN_ENABLED               | 1                                    | Enable/Disable the image scan pipeline                                             |
 | imagescan.grypeconfigfilename     | WFE_IMAGE_SCAN_GRYPE_CONFIG_FILENAME | -                                    | The config filename for the grype vulnerability report                             |
 | imagescan.grypefilename           | WFE_IMAGE_SCAN_GRYPE_FILENAME        | grype-vulnerability-report-full.json | The filename for the grype vulnerability report - must contain 'grype'             |
 | imagescan.syftfilename            | WFE_IMAGE_SCAN_SYFT_FILENAME         | syft-sbom-report.json                | The filename for the syft SBOM report - must contain 'syft'                        |
+
 
 ## Running in Docker
 

--- a/cmd/workflow-engine/cli/config.go
+++ b/cmd/workflow-engine/cli/config.go
@@ -37,13 +37,19 @@ func newConfigCommand() *cobra.Command {
 		Short:   "generate documentation or github action files",
 	}
 
+	genCmd.PersistentFlags().StringP("image", "i", "", "workflow engine image name")
+	_ = genCmd.MarkFlagRequired("image")
+	genCmd.Flags().StringP("image", "i", "", "workflow engine image name")
+
+	codeScanActionCmd := newBasicCommand("code-scan-action", "generate a github action for the code scan pipeline outputs to STDOUT", runGenCodeScanAction)
 	imageBuildActionCmd := newBasicCommand("image-build-action", "generate a github action for the image build pipeline outputs to STDOUT", runGenImageBuildAction)
-	imageBuildActionCmd.Flags().StringP("image", "i", "", "workflow engine image name")
-	_ = imageBuildActionCmd.MarkFlagRequired("image")
+	imageScanActionCmd := newBasicCommand("image-scan-action", "generate a github action for the image scan pipeline outputs to STDOUT", runGenImageScanAction)
+	imagePublishActionCmd := newBasicCommand("image-publish-action", "generate a github action for the image publish pipeline outputs to STDOUT", runGenImagePublishAction)
+	deployActionCmd := newBasicCommand("deploy-action", "generate a github action for the deploy pipeline outputs to STDOUT", runGenDeployAction)
 
 	markdownCmd := newBasicCommand("markdown-table", "generate a markdown table with all of the keys, env variables, and defaults", runGenMarkdown)
 
-	genCmd.AddCommand(imageBuildActionCmd, markdownCmd)
+	genCmd.AddCommand(codeScanActionCmd, imageBuildActionCmd, imageScanActionCmd, imagePublishActionCmd, deployActionCmd, markdownCmd)
 
 	// config
 	cmd := &cobra.Command{Use: "config", Short: "manage the workflow engine config file"}
@@ -55,9 +61,25 @@ func newConfigCommand() *cobra.Command {
 }
 
 // Run Functions - Parsing flags and arguments at command runtime
+func runGenCodeScanAction(cmd *cobra.Command, args []string) error {
+	wfeImage, _ := cmd.Flags().GetString("image")
+	return pipelines.WriteGithubActionCodeScan(cmd.OutOrStdout(), wfeImage)
+}
 func runGenImageBuildAction(cmd *cobra.Command, args []string) error {
 	wfeImage, _ := cmd.Flags().GetString("image")
 	return pipelines.WriteGithubActionImageBuild(cmd.OutOrStdout(), wfeImage)
+}
+func runGenImageScanAction(cmd *cobra.Command, args []string) error {
+	wfeImage, _ := cmd.Flags().GetString("image")
+	return pipelines.WriteGithubActionImageScan(cmd.OutOrStdout(), wfeImage)
+}
+func runGenImagePublishAction(cmd *cobra.Command, args []string) error {
+	wfeImage, _ := cmd.Flags().GetString("image")
+	return pipelines.WriteGithubActionImagePublish(cmd.OutOrStdout(), wfeImage)
+}
+func runGenDeployAction(cmd *cobra.Command, args []string) error {
+	wfeImage, _ := cmd.Flags().GetString("image")
+	return pipelines.WriteGithubActionDeploy(cmd.OutOrStdout(), wfeImage)
 }
 
 func runConfigInfo(cmd *cobra.Command, args []string) error {

--- a/cmd/workflow-engine/cli/config.go
+++ b/cmd/workflow-engine/cli/config.go
@@ -37,9 +37,9 @@ func newConfigCommand() *cobra.Command {
 		Short:   "generate documentation or github action files",
 	}
 
+	genCmd.PersistentFlags().String("docker-alias", "docker", "an Docker CLI compatible alias [docker/podman]")
 	genCmd.PersistentFlags().StringP("image", "i", "", "workflow engine image name")
 	_ = genCmd.MarkFlagRequired("image")
-	genCmd.Flags().StringP("image", "i", "", "workflow engine image name")
 
 	codeScanActionCmd := newBasicCommand("code-scan-action", "generate a github action for the code scan pipeline outputs to STDOUT", runGenCodeScanAction)
 	imageBuildActionCmd := newBasicCommand("image-build-action", "generate a github action for the image build pipeline outputs to STDOUT", runGenImageBuildAction)
@@ -67,15 +67,18 @@ func runGenCodeScanAction(cmd *cobra.Command, args []string) error {
 }
 func runGenImageBuildAction(cmd *cobra.Command, args []string) error {
 	wfeImage, _ := cmd.Flags().GetString("image")
-	return pipelines.WriteGithubActionImageBuild(cmd.OutOrStdout(), wfeImage)
+	alias, _ := cmd.Flags().GetString("docker-alias")
+	return pipelines.WriteGithubActionImageBuild(cmd.OutOrStdout(), wfeImage, alias)
 }
 func runGenImageScanAction(cmd *cobra.Command, args []string) error {
 	wfeImage, _ := cmd.Flags().GetString("image")
-	return pipelines.WriteGithubActionImageScan(cmd.OutOrStdout(), wfeImage)
+	alias, _ := cmd.Flags().GetString("docker-alias")
+	return pipelines.WriteGithubActionImageScan(cmd.OutOrStdout(), wfeImage, alias)
 }
 func runGenImagePublishAction(cmd *cobra.Command, args []string) error {
 	wfeImage, _ := cmd.Flags().GetString("image")
-	return pipelines.WriteGithubActionImagePublish(cmd.OutOrStdout(), wfeImage)
+	alias, _ := cmd.Flags().GetString("docker-alias")
+	return pipelines.WriteGithubActionImagePublish(cmd.OutOrStdout(), wfeImage, alias)
 }
 func runGenDeployAction(cmd *cobra.Command, args []string) error {
 	wfeImage, _ := cmd.Flags().GetString("image")

--- a/cmd/workflow-engine/cli/pipelines.go
+++ b/cmd/workflow-engine/cli/pipelines.go
@@ -74,7 +74,7 @@ func newRunCommand() *cobra.Command {
 	// run deploy
 	deployCmd := newBasicCommand("deploy", "Beta Feature: VALIDATION ONLY - run gatecheck validate on artifacts from previous pipelines", runDeploy)
 	deployCmd.Flags().String("gatecheck-config", "", "gatecheck configuration file")
-	_ = viper.BindPFlag("deploy.gatecheckConfigFilename", deployCmd.Flags().Lookup("gatecheck-config"))
+	_ = viper.BindPFlag("deploy.gatecheckconfigfilename", deployCmd.Flags().Lookup("gatecheck-config"))
 
 	// run
 	cmd := &cobra.Command{Use: "run", Short: "run a pipeline"}

--- a/cmd/workflow-engine/cli/root.go
+++ b/cmd/workflow-engine/cli/root.go
@@ -15,8 +15,7 @@ var (
 
 func NewWorkflowEngineCommand() *cobra.Command {
 	viper.SetConfigName("workflow-engine")
-	pipelines.BindEnvs(viper.GetViper())
-	pipelines.SetDefaults(viper.GetViper())
+	pipelines.BindViper(viper.GetViper())
 
 	versionCmd := newBasicCommand("version", "print version information", runVersion)
 	cmd := &cobra.Command{

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 INSTALL_DIR := env('INSTALL_DIR', '/usr/local/bin')
-
+WORKFLOW_ENGINE_IMAGE := "ghcr.io/cms-enterprise/batcave/workflow-engine"
 
 # build workflow engine binary
 build:
@@ -22,19 +22,19 @@ fix:
 serve-docs:
 	mdbook serve
 
-gen-actions workflow-engine-image workflow-engine-podman-image:
+gen-actions version-tag:
     mkdir -p .github/actions/code-scan/
-    workflow-engine config gen code-scan-action -i {{ workflow-engine-image }} > .github/actions/code-scan/action.yml
+    workflow-engine config gen code-scan-action -i {{ WORKFLOW_ENGINE_IMAGE }}:{{ version-tag }} > .github/actions/code-scan/action.yml
     mkdir -p .github/actions/image-build/
-    workflow-engine config gen image-build-action -i {{ workflow-engine-image }} > .github/actions/image-build/action.yml
+    workflow-engine config gen image-build-action -i {{ WORKFLOW_ENGINE_IMAGE }}:{{ version-tag }} > .github/actions/image-build/action.yml
     mkdir -p .github/actions/image-scan/
-    workflow-engine config gen image-scan-action -i {{ workflow-engine-image }} > .github/actions/image-scan/action.yml
+    workflow-engine config gen image-scan-action -i {{ WORKFLOW_ENGINE_IMAGE }}:{{ version-tag }} > .github/actions/image-scan/action.yml
     mkdir -p .github/actions/image-publish/
-    workflow-engine config gen image-publish-action -i {{ workflow-engine-image }} > .github/actions/image-publish/action.yml
+    workflow-engine config gen image-publish-action -i {{ WORKFLOW_ENGINE_IMAGE }}:{{ version-tag }} > .github/actions/image-publish/action.yml
     mkdir -p .github/actions/image-build-podman/
 
-    workflow-engine config gen image-build-action -i {{ workflow-engine-podman-image }} > .github/actions/image-build/action.yml
+    workflow-engine config gen image-build-action --docker-alias podman -i {{ WORKFLOW_ENGINE_IMAGE }}:podman-{{ version-tag }} > .github/actions/image-build-podman/action.yml
     mkdir -p .github/actions/image-scan-podman/
-    workflow-engine config gen image-scan-action -i {{ workflow-engine-podman-image }} > .github/actions/image-scan/action.yml
+    workflow-engine config gen image-scan-action --docker-alias podman -i {{ WORKFLOW_ENGINE_IMAGE }}:podman-{{ version-tag }} > .github/actions/image-scan-podman/action.yml
     mkdir -p .github/actions/image-publish-podman/
-    workflow-engine config gen image-publish-action -i {{ workflow-engine-podman-image }} > .github/actions/image-publish/action.yml
+    workflow-engine config gen image-publish-action --docker-alias podman -i {{ WORKFLOW_ENGINE_IMAGE }}:podman-{{ version-tag }} > .github/actions/image-publish-podman/action.yml

--- a/justfile
+++ b/justfile
@@ -22,3 +22,19 @@ fix:
 serve-docs:
 	mdbook serve
 
+gen-actions workflow-engine-image workflow-engine-podman-image:
+    mkdir -p .github/actions/code-scan/
+    workflow-engine config gen code-scan-action -i {{ workflow-engine-image }} > .github/actions/code-scan/action.yml
+    mkdir -p .github/actions/image-build/
+    workflow-engine config gen image-build-action -i {{ workflow-engine-image }} > .github/actions/image-build/action.yml
+    mkdir -p .github/actions/image-scan/
+    workflow-engine config gen image-scan-action -i {{ workflow-engine-image }} > .github/actions/image-scan/action.yml
+    mkdir -p .github/actions/image-publish/
+    workflow-engine config gen image-publish-action -i {{ workflow-engine-image }} > .github/actions/image-publish/action.yml
+    mkdir -p .github/actions/image-build-podman/
+
+    workflow-engine config gen image-build-action -i {{ workflow-engine-podman-image }} > .github/actions/image-build/action.yml
+    mkdir -p .github/actions/image-scan-podman/
+    workflow-engine config gen image-scan-action -i {{ workflow-engine-podman-image }} > .github/actions/image-scan/action.yml
+    mkdir -p .github/actions/image-publish-podman/
+    workflow-engine config gen image-publish-action -i {{ workflow-engine-podman-image }} > .github/actions/image-publish/action.yml

--- a/pkg/pipelines/config.go
+++ b/pkg/pipelines/config.go
@@ -1,133 +1,349 @@
 package pipelines
 
 import (
+	"errors"
 	"fmt"
 	"html/template"
 	"io"
 	"log/slog"
+	"slices"
+	"strings"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
 )
 
 // Config contains all parameters for the various pipelines
 type Config struct {
-	Version                 string             `json:"version"                 toml:"version"                 yaml:"version"`
-	ImageTag                string             `json:"imageTag"                toml:"imageTag"                yaml:"imageTag"`
-	ImageBuild              configImageBuild   `json:"imageBuild"              toml:"imageBuild"              yaml:"imageBuild"`
-	ImageScan               configImageScan    `json:"imageScan"               toml:"imageScan"               yaml:"imageScan"`
-	CodeScan                configCodeScan     `json:"codeScan"                toml:"codeScan"                yaml:"codeScan"`
-	ImagePublish            configImagePublish `json:"imagePublish"            toml:"imagePublish"            yaml:"imagePublish"`
-	Deploy                  configDeploy       `json:"deploy"                  toml:"deploy"                  yaml:"deploy"`
-	ArtifactDir             string             `json:"artifactDir"             toml:"artifactDir"             yaml:"artifactDir"`
-	GatecheckBundleFilename string             `json:"gatecheckBundleFilename" toml:"gatecheckBundleFilename" yaml:"gatecheckBundleFilename"`
+	Version                 string             `mapstructure:"version"`
+	ImageTag                string             `mapstructure:"imageTag"`
+	ArtifactDir             string             `mapstructure:"artifactDir"`
+	GatecheckBundleFilename string             `mapstructure:"gatecheckBundleFilename"`
+	ImageBuild              configImageBuild   `mapstructure:"imageBuild"`
+	ImageScan               configImageScan    `mapstructure:"imageScan"`
+	CodeScan                configCodeScan     `mapstructure:"codeScan"`
+	ImagePublish            configImagePublish `mapstructure:"imagePublish"`
+	Deploy                  configDeploy       `mapstructure:"deploy"`
 }
 
 type configImageBuild struct {
-	Enabled      bool     `json:"enabled"      toml:"enabled"      yaml:"enabled"`
-	BuildDir     string   `json:"buildDir"     toml:"buildDir"     yaml:"buildDir"`
-	Dockerfile   string   `json:"dockerfile"   toml:"dockerfile"   yaml:"dockerfile"`
-	Platform     string   `json:"platform"     toml:"platform"     yaml:"platform"`
-	Target       string   `json:"target"       toml:"target"       yaml:"target"`
-	CacheTo      string   `json:"cacheTo"      toml:"cacheTo"      yaml:"cacheTo"`
-	CacheFrom    string   `json:"cacheFrom"    toml:"cacheFrom"    yaml:"cacheFrom"`
-	SquashLayers bool     `json:"squashLayers" toml:"squashLayers" yaml:"squashLayers"`
-	Args         []string `json:"args"         toml:"args"         yaml:"args"`
-	ScanTarget   string   `json:"scanTarget"   toml:"scanTarget"   yaml:"scanTarget"`
+	Enabled      bool     `mapstructure:"enabled"`
+	BuildDir     string   `mapstructure:"buildDir"`
+	Dockerfile   string   `mapstructure:"dockerfile"`
+	Platform     string   `mapstructure:"platform"`
+	Target       string   `mapstructure:"target"`
+	CacheTo      string   `mapstructure:"cacheTo"`
+	CacheFrom    string   `mapstructure:"cacheFrom"`
+	SquashLayers bool     `mapstructure:"squashLayers"`
+	Args         []string `mapstructure:"args"`
 }
 
 type configImageScan struct {
-	Enabled             bool   `json:"enabled"             toml:"enabled"             yaml:"enabled"`
-	SyftFilename        string `json:"syftFilename"        toml:"syftFilename"        yaml:"syftFilename"`
-	GrypeConfigFilename string `json:"grypeConfigFilename" toml:"grypeConfigFilename" yaml:"grypeConfigFilename"`
-	GrypeActiveFilename string `json:"grypeActiveFilename" toml:"grypeActiveFilename" yaml:"grypeActiveFilename"`
-	GrypeFullFilename   string `json:"grypeFullFilename"   toml:"grypeFullFilename"   yaml:"grypeFullFilename"`
-	ClamavFilename      string `json:"clamavFilename"      toml:"clamavFilename"      yaml:"clamavFilename"`
+	Enabled             bool   `mapstructure:"enabled"`
+	SyftFilename        string `mapstructure:"syftFilename"`
+	GrypeConfigFilename string `mapstructure:"grypeConfigFilename"`
+	GrypeActiveFilename string `mapstructure:"grypeActiveFilename"`
+	GrypeFullFilename   string `mapstructure:"grypeFullFilename"`
+	ClamavFilename      string `mapstructure:"clamavFilename"`
 }
 
 type configCodeScan struct {
-	Enabled          bool   `json:"enabled"          toml:"enabled"          yaml:"enabled"`
-	GitleaksFilename string `json:"gitleaksFilename" toml:"gitleaksFilename" yaml:"gitleaksFilename"`
-	GitleaksSrcDir   string `json:"gitleaksSrcDir"   toml:"gitleaksSrcDir"   yaml:"gitleaksSrcDir"`
-	SemgrepFilename  string `json:"semgrepFilename"  toml:"semgrepFilename"  yaml:"semgrepFilename"`
-	SemgrepRules     string `json:"semgrepRules"     toml:"semgrepRules"     yaml:"semgrepRules"`
+	Enabled          bool   `mapstructure:"enabled"`
+	GitleaksFilename string `mapstructure:"gitleaksFilename"`
+	GitleaksSrcDir   string `mapstructure:"gitleaksSrcDir"`
+	SemgrepFilename  string `mapstructure:"semgrepFilename"`
+	SemgrepRules     string `mapstructure:"semgrepRules"`
 }
 
 type configImagePublish struct {
-	Enabled              bool   `json:"enabled"              toml:"enabled"              yaml:"enabled"`
-	BundlePublishEnabled bool   `json:"bundlePublishEnabled" toml:"bundlePublishEnabled" yaml:"bundlePublishEnabled"`
-	BundleTag            string `json:"bundleTag"            toml:"bundleTag"            yaml:"bundleTag"`
+	Enabled              bool   `mapstructure:"enabled"`
+	BundlePublishEnabled bool   `mapstructure:"bundlePublishEnabled"`
+	BundleTag            string `mapstructure:"bundleTag"`
 }
 
 type configDeploy struct {
-	Enabled                 bool   `json:"enabled" toml:"enabled" yaml:"enabled"`
-	GatecheckConfigFilename string `json:"gatecheckConfigFilename" toml:"gatecheckConfigFilename" yaml:"gatecheckConfigFilename"`
+	Enabled                 bool   `mapstructure:"enabled"`
+	GatecheckConfigFilename string `mapstructure:"gatecheckConfigFilename"`
 }
 
-func BindEnvs(v *viper.Viper) {
-	v.MustBindEnv("artifactdir", "WFE_ARTIFACT_DIR")
-	v.MustBindEnv("gatecheckBundleFilename", "WFE_GATECHECK_BUNDLE_FILENAME")
-	v.MustBindEnv("imagetag", "WFE_IMAGE_TAG")
-
-	v.MustBindEnv("imagebuild.enabled", "WFE_IMAGE_BUILD_ENABLED")
-	v.MustBindEnv("imagebuild.builddir", "WFE_IMAGE_BUILD_DIR")
-	v.MustBindEnv("imagebuild.dockerfile", "WFE_IMAGE_BUILD_DOCKERFILE")
-	v.MustBindEnv("imagebuild.platform", "WFE_BUILD_IMAGE_PLATFORM")
-	v.MustBindEnv("imagebuild.target", "WFE_IMAGE_BUILD_TARGET")
-	v.MustBindEnv("imagebuild.cacheto", "WFE_IMAGE_BUILD_CACHE_TO")
-	v.MustBindEnv("imagebuild.cachefrom", "WFE_IMAGE_BUILD_CACHE_FROM")
-	v.MustBindEnv("imagebuild.squashlayers", "WFE_IMAGE_BUILD_SQUASH_LAYERS")
-	v.MustBindEnv("imagebuild.args", "WFE_IMAGE_BUILD_ARGS")
-
-	v.MustBindEnv("imagescan.enabled", "WFE_IMAGE_SCAN_ENABLED")
-	v.MustBindEnv("imagescan.clamavFilename", "WFE_IMAGE_SCAN_CLAMAV_FILENAME")
-	v.MustBindEnv("imagescan.syftFilename", "WFE_IMAGE_SCAN_SYFT_FILENAME")
-	v.MustBindEnv("imagescan.grypeConfigFilename", "WFE_IMAGE_SCAN_GRYPE_CONFIG_FILENAME")
-	v.MustBindEnv("imagescan.grypeActiveFindingsFilename", "WFE_IMAGE_SCAN_GRYPE_ACTIVE_FINDINGS_FILENAME")
-	v.MustBindEnv("imagescan.grypeAllFindingsFilename", "WFE_IMAGE_SCAN_GRYPE_ALL_FINDINGS_FILENAME")
-
-	v.MustBindEnv("codescan.enabled", "WFE_CODE_SCAN_ENABLED")
-	v.MustBindEnv("codescan.gitleaksFilename", "WFE_CODE_SCAN_GITLEAKS_FILENAME")
-	v.MustBindEnv("codescan.gitleaksSrcDir", "WFE_CODE_SCAN_GITLEAKS_SRC_DIR")
-	v.MustBindEnv("codescan.semgrepFilename", "WFE_CODE_SCAN_SEMGREP_FILENAME")
-	v.MustBindEnv("codescan.semgrepRules", "WFE_CODE_SCAN_SEMGREP_RULES")
-
-	v.MustBindEnv("imagepublish.enabled", "WFE_IMAGE_PUBLISH_ENABLED")
-	v.MustBindEnv("imagepublish.bundlepublishenabled", "WFE_IMAGE_PUBLISH_BUNDLE_PUBLISH_ENABLED")
-	v.MustBindEnv("imagepublish.bundletag", "WFE_BUNDLE_TAG")
-
-	v.MustBindEnv("deploy.enabled", "WFE_DEPLOY_ENABLED")
-	v.MustBindEnv("deploy.gatecheckConfigFilename", "WFE_GATECHECK_CONFIG_FILENAME")
+// metaConfigField is used to map viper values to env variables and their associated default values
+type metaConfigField struct {
+	Key         string
+	Env         string
+	Default     any
+	Description string
 }
 
-func SetDefaults(v *viper.Viper) {
-	v.SetDefault("version", "1")
-	v.SetDefault("artifactdir", "artifacts")
-	v.SetDefault("imagetag", "my-app:latest")
+var metaConfig = []metaConfigField{
+	{Key: "imagetag", Env: "WFE_IMAGE_TAG", Default: "my-app:latest",
+		Description: "The full image tag for the target container image"},
 
-	v.SetDefault("gatecheckBundleFilename", "gatecheck-bundle.tar.gz")
+	{Key: "artifactdir", Env: "WFE_ARTIFACT_DIR", Default: "artifacts",
+		Description: "The target directory for all generated artifacts",
+	},
+	{Key: "gatecheckbundlefilename", Env: "WFE_GATECHECK_BUNDLE_FILENAME", Default: "artifacts/gatecheck-bundle.tar.gz",
+		Description: "The filename for the gatecheck bundle, a validatable archive of security artifacts",
+	},
 
-	v.SetDefault("imagebuild.enabled", "1")
-	v.SetDefault("imagebuild.builddir", ".")
-	v.SetDefault("imagebuild.dockerfile", "Dockerfile")
+	{Key: "imagebuild.enabled", Env: "WFE_IMAGE_BUILD_ENABLED", Default: true,
+		Description: "Enable/Disable the image build pipeline",
+	},
+	{Key: "imagebuild.builddir", Env: "WFE_IMAGE_BUILD_DIR", Default: ".",
+		Description: "The build directory to using during an image build",
+	},
+	{Key: "imagebuild.dockerfile", Env: "WFE_IMAGE_BUILD_DOCKERFILE", Default: "Dockerfile",
+		Description: "The Dockerfile/Containerfile to use during an image build",
+	},
+	{Key: "imagebuild.platform", Env: "WFE_IMAGE_BUILD_PLATFORM", Default: nil,
+		Description: "The target platform for build",
+	},
+	{Key: "imagebuild.target", Env: "WFE_IMAGE_BUILD_TARGET", Default: nil,
+		Description: "The target build stage to build (e.g., [linux/amd64])",
+	},
+	{Key: "imagebuild.cacheto", Env: "WFE_IMAGE_BUILD_CACHE_TO", Default: nil,
+		Description: "Cache export destinations (e.g., \"user/app:cache\", \"type=local,src=path/to/dir\")",
+	},
+	{Key: "imagebuild.cachefrom", Env: "WFE_IMAGE_BUILD_CACHE_FROM", Default: nil,
+		Description: "External cache sources (e.g., \"user/app:cache\", \"type=local,src=path/to/dir\")",
+	},
+	{Key: "imagebuild.squashlayers", Env: "WFE_IMAGE_BUILD_SQUASH_LAYERS", Default: false,
+		Description: "squash image layers - Only Supported with Podman CLI",
+	},
+	{Key: "imagebuild.args", Env: "WFE_IMAGE_BUILD_ARGS", Default: nil,
+		Description: "Comma seperated list of build time variables",
+	},
 
-	v.SetDefault("imagescan.enabled", "1")
-	v.SetDefault("imagescan.clamavFilename", "clamav-virus-report.txt")
-	v.SetDefault("imagescan.syftFilename", "syft-sbom-report.json")
-	v.SetDefault("imagescan.grypeActiveFilename", "grype-vulnerability-report-active.json")
-	v.SetDefault("imagescan.grypeFullFilename", "grype-vulnerability-report-full.json")
+	{Key: "imagescan.enabled", Env: "WFE_IMAGE_SCAN_ENABLED", Default: true,
+		Description: "Enable/Disable the image scan pipeline",
+	},
+	{Key: "imagescan.syftfilename", Env: "WFE_IMAGE_SCAN_SYFT_FILENAME", Default: "syft-sbom-report.json",
+		Description: "The filename for the syft SBOM report - must contain 'syft'",
+	},
+	{Key: "imagescan.grypeconfigfilename", Env: "WFE_IMAGE_SCAN_GRYPE_CONFIG_FILENAME", Default: nil,
+		Description: "The config filename for the grype vulnerability report",
+	},
+	{Key: "imagescan.grypefilename", Env: "WFE_IMAGE_SCAN_GRYPE_FILENAME", Default: "grype-vulnerability-report-full.json",
+		Description: "The filename for the grype vulnerability report - must contain 'grype'",
+	},
+	{Key: "imagescan.clamavFilename", Env: "WFE_IMAGE_SCAN_CLAMAV_FILENAME", Default: "clamav-virus-report.txt",
+		Description: "The filename for the clamscan virus report - must contain 'clamav'",
+	},
 
-	v.SetDefault("codescan.enabled", "1")
-	v.SetDefault("codescan.gitleaksFilename", "gitleaks-secrets-report.json")
-	v.SetDefault("codescan.gitleaksSrcDir", ".")
-	v.SetDefault("codescan.semgrepFilename", "semgrep-sast-report.json")
-	v.SetDefault("codescan.semgrepRules", "p/default")
+	{Key: "codescan.enabled", Env: "WFE_CODE_SCAN_ENABLED", Default: true,
+		Description: "Enable/Disable the code scan pipeline",
+	},
+	{Key: "codescan.gitleaksfilename", Env: "WFE_CODE_SCAN_GITLEAKS_FILENAME", Default: "gitleaks-secrets-report.json",
+		Description: "The filename for the gitleaks secret report - must contain 'gitleaks'",
+	},
+	{Key: "codescan.gitleakssrcdir", Env: "WFE_CODE_SCAN_GITLEAKS_SRC_DIR", Default: ".",
+		Description: "The target directory for the gitleaks scan",
+	},
+	{Key: "codescan.semgrepfilename", Env: "WFE_CODE_SCAN_SEMGREP_FILENAME", Default: "semgrep-sast-report.json",
+		Description: "The filename for the semgrep SAST report - must contain 'semgrep'",
+	},
+	{Key: "codescan.semgreprules", Env: "WFE_CODE_SCAN_SEMGREP_RULES", Default: "p/default",
+		Description: "Semgrep ruleset manual override",
+	},
 
-	v.SetDefault("imagepublish.enabled", "1")
-	v.SetDefault("imagepublish.bundlepublishenabled", "1")
-	v.SetDefault("imagepublish.bundletag", "my-app/artifact-bundle:latest")
+	{Key: "imagepublish.enabled", Env: "WFE_IMAGE_PUBLISH_ENABLED", Default: true,
+		Description: "Enable/Disable the image publish pipeline",
+	},
+	{Key: "imagepublish.bundlepublishenabled", Env: "WFE_IMAGE_BUNDLE_PUBLISH_ENABLED", Default: true,
+		Description: "Enable/Disable gatecheck artifact bundle publish task",
+	},
+	{Key: "imagepublish.bundletag", Env: "WFE_IMAGE_PUBLISH_BUNDLE_TAG", Default: "my-app/artifact-bundle:latest",
+		Description: "The full image tag for the target gatecheck bundle image blob",
+	},
 
-	v.SetDefault("deploy.enabled", "1")
+	{Key: "deploy.enabled", Env: "WFE_IMAGE_PUBLISH_ENABLED", Default: true,
+		Description: "Enable/Disable the deploy pipeline",
+	},
+	{Key: "deploy.gatecheckconfigfilename", Env: "WFE_DEPLOY_GATECHECK_CONFIG_FILENAME", Default: nil,
+		Description: "The filename for the gatecheck config",
+	},
+}
+
+func metaConfigLookup(key string) metaConfigField {
+	for _, value := range metaConfig {
+		if value.Key == key {
+			return value
+		}
+	}
+	return metaConfigField{}
+}
+
+func BindViper(v *viper.Viper) {
+	for _, field := range metaConfig {
+		viper.MustBindEnv(field.Key, field.Env)
+		if field.Default != nil {
+			viper.SetDefault(field.Key, field.Env)
+		}
+	}
+}
+
+type imageBuildAction struct {
+	Name        string                      `yaml:"name"`
+	Description string                      `yaml:"description"`
+	Inputs      map[string]actionInputField `yaml:"inputs"`
+	Runs        actionRunsConfig            `yaml:"runs"`
+}
+
+type actionInputField struct {
+	Description string `yaml:"description"`
+	Default     string `yaml:"default,omitempty"`
+}
+
+type actionRunsConfig struct {
+	Using string            `yaml:"using"`
+	Image string            `yaml:"image"`
+	Args  []string          `yaml:"args,flow"`
+	Env   map[string]string `yaml:"env"`
+}
+
+func paddedMetaConfigData() [][4]string {
+	data := [][4]string{{"Config Key", "Environment Variable", "Default Value", "Description"}}
+
+	maxLens := []int{
+		len(data[0][0]),
+		len(data[0][1]),
+		len(data[0][2]),
+		len(data[0][3]),
+	}
+	printableMetaConfig := slices.Clone(metaConfig)
+
+	// find the max length for each field in the slice
+	for i := range printableMetaConfig {
+		if printableMetaConfig[i].Default == nil {
+			printableMetaConfig[i].Default = "-"
+		}
+		enabled, ok := printableMetaConfig[i].Default.(bool)
+		if ok {
+			printableMetaConfig[i].Default = "0"
+			if enabled {
+				printableMetaConfig[i].Default = "1"
+			}
+		}
+
+		maxLens[0] = max(len(printableMetaConfig[i].Key), maxLens[0])
+		maxLens[1] = max(len(printableMetaConfig[i].Env), maxLens[1])
+		maxLens[2] = max(len(printableMetaConfig[i].Default.(string)), maxLens[2])
+		maxLens[3] = max(len(printableMetaConfig[i].Description), maxLens[3])
+	}
+
+	slices.SortFunc(printableMetaConfig, func(a, b metaConfigField) int {
+		return strings.Compare(a.Key, b.Key)
+	})
+
+	for i := 0; i < 4; i++ {
+		// adjust header row
+		format := fmt.Sprintf("%%-%ds", maxLens[i])
+		data[0][i] = fmt.Sprintf(format, data[0][i])
+	}
+
+	for i := 1; i < len(printableMetaConfig); i++ {
+
+		data = append(data, [4]string{})
+		format := fmt.Sprintf("%%-%ds", maxLens[0])
+		data[i][0] = fmt.Sprintf(format, printableMetaConfig[i].Key)
+
+		format = fmt.Sprintf("%%-%ds", maxLens[1])
+		data[i][1] = fmt.Sprintf(format, printableMetaConfig[i].Env)
+
+		format = fmt.Sprintf("%%-%ds", maxLens[2])
+		data[i][2] = fmt.Sprintf(format, printableMetaConfig[i].Default)
+
+		format = fmt.Sprintf("%%-%ds", maxLens[3])
+		data[i][3] = fmt.Sprintf(format, printableMetaConfig[i].Description)
+	}
+
+	return data
+}
+
+func WriteMarkdownEnv(dst io.Writer) error {
+	data := paddedMetaConfigData()
+
+	// header
+	var headerErr error
+	_, headerErr = fmt.Fprintf(dst, "| %s | %s | %s | %s |\n",
+		data[0][0],
+		data[0][1],
+		data[0][2],
+		data[0][3],
+	)
+
+	// header seperator
+	_, err := fmt.Fprintf(dst, "| %s | %s | %s | %s |\n",
+		strings.Repeat("-", len(data[0][0])),
+		strings.Repeat("-", len(data[0][1])),
+		strings.Repeat("-", len(data[0][2])),
+		strings.Repeat("-", len(data[0][3])),
+	)
+
+	headerErr = errors.Join(headerErr, err)
+	if headerErr != nil {
+		return headerErr
+	}
+
+	// Rows of content, skip header
+	for i := 1; i < len(data)-1; i++ {
+		_, err = fmt.Fprintf(dst, "| %s | %s | %s | %s |\n", data[i][0], data[i][1], data[i][2], data[i][3])
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func WriteGithubActionImageBuild(dst io.Writer, image string) error {
+	supportedKeys := []struct {
+		key        string
+		inputField string
+	}{
+		{key: "imagebuild.builddir", inputField: "build_dir"},
+		{key: "imagebuild.dockerfile", inputField: "dockerfile"},
+		{key: "imagebuild.args", inputField: "args"},
+		{key: "imagetag", inputField: "image_tag"},
+		{key: "imagebuild.platform", inputField: "platform"},
+		{key: "imagebuild.target", inputField: "target"},
+		{key: "imagebuild.cacheto", inputField: "cache_to"},
+		{key: "imagebuild.cachefrom", inputField: "cache_from"},
+		{key: "imagebuild.squashlayers", inputField: "squash_layers"},
+	}
+
+	action := imageBuildAction{
+		Name:        "Build Image",
+		Description: "Build a container image with Workflow Engine",
+		Inputs: map[string]actionInputField{
+			"config_file": {
+				Description: "The workflow engine config file name",
+				Default:     "",
+			},
+		},
+		Runs: actionRunsConfig{
+			Using: "docker",
+			Image: image,
+			Args:  []string{"run", "image-build", "--config", "${{ inputs.config_file }}", "--verbose"},
+			Env:   map[string]string{},
+		},
+	}
+
+	for _, field := range supportedKeys {
+		configField := metaConfigLookup(field.key)
+		defaultValue, ok := configField.Default.(string)
+		if !ok {
+			defaultValue = ""
+		}
+		action.Inputs[field.inputField] = actionInputField{
+			Description: configField.Description,
+			Default:     defaultValue,
+		}
+		action.Runs.Env[configField.Env] = fmt.Sprintf("${{ inputs.%s }}", field.key)
+	}
+
+	enc := yaml.NewEncoder(dst)
+	enc.SetIndent(2)
+	return enc.Encode(action)
 }
 
 func RenderTemplate(dst io.Writer, templateSrc io.Reader) error {

--- a/pkg/pipelines/config.go
+++ b/pkg/pipelines/config.go
@@ -81,7 +81,7 @@ var metaConfig = []metaConfigField{
 	{Key: "artifactdir", Env: "WFE_ARTIFACT_DIR", Default: "artifacts",
 		Description: "The target directory for all generated artifacts",
 	},
-	{Key: "gatecheckbundlefilename", Env: "WFE_GATECHECK_BUNDLE_FILENAME", Default: "artifacts/gatecheck-bundle.tar.gz",
+	{Key: "gatecheckbundlefilename", Env: "WFE_GATECHECK_BUNDLE_FILENAME", Default: "gatecheck-bundle.tar.gz",
 		Description: "The filename for the gatecheck bundle, a validatable archive of security artifacts",
 	},
 
@@ -235,7 +235,7 @@ func WriteGithubActionCodeScan(dst io.Writer, image string) error {
 	return writeAction(action, supportedFields, dst)
 }
 
-func WriteGithubActionImageBuild(dst io.Writer, image string) error {
+func WriteGithubActionImageBuild(dst io.Writer, image string, alias string) error {
 	supportedFields := []supportedField{
 		{key: "imagetag", inputField: "image_tag"},
 		{key: "artifactdir", inputField: "artifact_dir"},
@@ -262,7 +262,7 @@ func WriteGithubActionImageBuild(dst io.Writer, image string) error {
 		Runs: actionRunsConfig{
 			Using: "docker",
 			Image: image,
-			Args:  []string{"run", "image-build", "--config", "${{ inputs.config_file }}", "--verbose"},
+			Args:  []string{"run", "image-build", "--cli-interface", alias, "--config", "${{ inputs.config_file }}", "--verbose"},
 			Env:   map[string]string{},
 		},
 	}
@@ -270,9 +270,10 @@ func WriteGithubActionImageBuild(dst io.Writer, image string) error {
 	return writeAction(action, supportedFields, dst)
 }
 
-func WriteGithubActionImageScan(dst io.Writer, image string) error {
+func WriteGithubActionImageScan(dst io.Writer, image string, alias string) error {
 	supportedFields := []supportedField{
 		{key: "artifactdir", inputField: "artifact_dir"},
+		{key: "imagetag", inputField: "image_tag"},
 		{key: "gatecheckbundlefilename", inputField: "gatecheck_bundle_filename"},
 		{key: "imagescan.syftfilename", inputField: "syft_filename"},
 		{key: "imagescan.grypeconfigfilename", inputField: "grype_config_filename"},
@@ -292,7 +293,7 @@ func WriteGithubActionImageScan(dst io.Writer, image string) error {
 		Runs: actionRunsConfig{
 			Using: "docker",
 			Image: image,
-			Args:  []string{"run", "image-scan", "--config", "${{ inputs.config_file }}", "--verbose"},
+			Args:  []string{"run", "image-scan", "--cli-interface", alias, "--config", "${{ inputs.config_file }}", "--verbose"},
 			Env:   map[string]string{},
 		},
 	}
@@ -300,8 +301,9 @@ func WriteGithubActionImageScan(dst io.Writer, image string) error {
 	return writeAction(action, supportedFields, dst)
 }
 
-func WriteGithubActionImagePublish(dst io.Writer, image string) error {
+func WriteGithubActionImagePublish(dst io.Writer, image string, alias string) error {
 	supportedFields := []supportedField{
+		{key: "imagetag", inputField: "image_tag"},
 		{key: "imagepublish.bundletag", inputField: "bundle_tag"},
 		{key: "imagepublish.bundlepublishenabled", inputField: "bundle_publish_enabled"},
 	}
@@ -318,7 +320,7 @@ func WriteGithubActionImagePublish(dst io.Writer, image string) error {
 		Runs: actionRunsConfig{
 			Using: "docker",
 			Image: image,
-			Args:  []string{"run", "image-publish", "--config", "${{ inputs.config_file }}", "--verbose"},
+			Args:  []string{"run", "image-publish", "--cli-interface", alias, "--config", "${{ inputs.config_file }}", "--verbose"},
 			Env:   map[string]string{},
 		},
 	}

--- a/pkg/pipelines/image-scan.go
+++ b/pkg/pipelines/image-scan.go
@@ -77,7 +77,7 @@ func (p *ImageScan) preRun() error {
 		return err
 	}
 
-	p.runtime.grypeFilename = path.Join(p.config.ArtifactDir, p.config.ImageScan.GrypeFullFilename)
+	p.runtime.grypeFilename = path.Join(p.config.ArtifactDir, p.config.ImageScan.GrypeFilename)
 	p.runtime.grypeFile, err = OpenOrCreateFile(p.runtime.grypeFilename)
 	if err != nil {
 		slog.Error("cannot open grype sbom file", "filename", p.runtime.grypeFilename, "error", err)


### PR DESCRIPTION
This PR will refactor the pipeline configuration object to use mapstructure struct tags instead of having to maintain
json,yaml and toml tags. 
We will still support those report types but the management will be handed off to Viper which has libraries to 
do conversions based on the filename.

The config CLI will change a bit to be more consistent and work with the viper library for encoding/decoding

This PR also has code generation for GitHub actions to reduce the chances of mistyping environment variable names or 
the case where it changes in code but isn't updated in the action.

## Notes

The Publish Image pipeline action will need more work beyond this pull request.
The execution of the `docker push` happens inside the workflow engine container.
It doesn't respect the docker/login-action step that happens before.
Further investigation is required to determine why but for now, I'm marking it out of scope for this PR which is mostly
concerned with auto generation of Actions.
