### PR TITLE
Updated the GitHub action generation code to be more flexible.

### DIFF
--- a/cmd/workflow-engine/cli/config.go
+++ b/cmd/workflow-engine/cli/config.go
@@ -31,10 +31,13 @@ func newConfigCommand() *cobra.Command {
 	convertCmd.Args = cobra.ExactArgs(2)
 
 	generateActionCmd := newBasicCommand("generate-action", "generate a single action for all pipelines", runGenAllAction)
-	generateActionCmd.Flags().String("docker-alias", "docker", "an Docker CLI compatible alias [docker/podman]")
+	generateActionCmd.Flags().String("image", "Dockerfile", "The image or Dockerfile to use for the generated action")
+	generateActionCmd.Flags().StringSlice("input", make([]string, 0), "Additional input(s) to make available as environment variables (format: \"input:variable:default:description\")")
 
 	generateTableCmd := newBasicCommand("generate-table", "generate a markdown table with all of the keys, env variables, and defaults", runGenMarkdown)
 	generateActionsTableCmd := newBasicCommand("generate-action-table", "generate a markdown table designed for github actions documentation", runGenActionMarkdown)
+	generateActionsTableCmd.Flags().String("image", "Dockerfile", "The image or Dockerfile to use for the generated action")
+	generateActionsTableCmd.Flags().StringSlice("input", make([]string, 0), "Additional input(s) to make available as environment variables (format: \"input:variable:default:description\")")
 
 	// config
 	cmd := &cobra.Command{Use: "config", Short: "manage the workflow engine config file"}
@@ -47,8 +50,9 @@ func newConfigCommand() *cobra.Command {
 
 // Run Functions - Parsing flags and arguments at command runtime
 func runGenAllAction(cmd *cobra.Command, args []string) error {
-	alias, _ := cmd.Flags().GetString("docker-alias")
-	return pipelines.WriteGithubActionAll(cmd.OutOrStdout(), alias)
+	image, _ := cmd.Flags().GetString("image")
+	additionalInputs, _ := cmd.Flags().GetStringSlice("input")
+	return pipelines.WriteGithubActionAll(cmd.OutOrStdout(), image, additionalInputs)
 }
 
 func runConfigInfo(cmd *cobra.Command, args []string) error {
@@ -77,7 +81,8 @@ func runGenMarkdown(cmd *cobra.Command, args []string) error {
 }
 
 func runGenActionMarkdown(cmd *cobra.Command, args []string) error {
-	return pipelines.WriteConfigAsActionsTable(cmd.OutOrStdout())
+	additionalInputs, _ := cmd.Flags().GetStringSlice("input")
+	return pipelines.WriteConfigAsActionsTable(additionalInputs, cmd.OutOrStdout())
 }
 
 func runConfigVars(cmd *cobra.Command, _ []string) error {

--- a/cmd/workflow-engine/cli/pipelines.go
+++ b/cmd/workflow-engine/cli/pipelines.go
@@ -108,6 +108,7 @@ func newRunCommand() *cobra.Command {
 	// necessary for the persistent flags
 	_ = viper.BindPFlag("artifactdir", cmd.PersistentFlags().Lookup("artifact-dir"))
 	_ = viper.BindPFlag("imagetag", cmd.PersistentFlags().Lookup("tag"))
+	_ = viper.BindPFlag("config", cmd.PersistentFlags().Lookup("config"))
 
 	// Flag marks
 	_ = cmd.MarkFlagFilename("config", "json", "yaml", "yml", "toml")
@@ -131,7 +132,9 @@ func runDebug(cmd *cobra.Command, _ []string) error {
 
 func runDeploy(cmd *cobra.Command, _ []string) error {
 	dryRunEnabled, _ := cmd.Flags().GetBool("dry-run")
-	configFilename, _ := cmd.Flags().GetString("config")
+
+	v := viper.GetViper()
+	configFilename := v.GetString("config")
 
 	config := new(pipelines.Config)
 	if err := LoadOrDefault(configFilename, config, viper.GetViper()); err != nil {
@@ -144,10 +147,12 @@ func runDeploy(cmd *cobra.Command, _ []string) error {
 func runImageBuild(cmd *cobra.Command, _ []string) error {
 	dryRunEnabled, _ := cmd.Flags().GetBool("dry-run")
 	cliInterface, _ := cmd.Flags().GetString("cli-interface")
-	configFilename, _ := cmd.Flags().GetString("config")
+
+	v := viper.GetViper()
+	configFilename := v.GetString("config")
 
 	config := new(pipelines.Config)
-	if err := LoadOrDefault(configFilename, config, viper.GetViper()); err != nil {
+	if err := LoadOrDefault(configFilename, config, v); err != nil {
 		return err
 	}
 
@@ -157,10 +162,12 @@ func runImageBuild(cmd *cobra.Command, _ []string) error {
 func runImageScan(cmd *cobra.Command, _ []string) error {
 	dryRunEnabled, _ := cmd.Flags().GetBool("dry-run")
 	cliInterface, _ := cmd.Flags().GetString("cli-interface")
-	configFilename, _ := cmd.Flags().GetString("config")
+
+	v := viper.GetViper()
+	configFilename := v.GetString("config")
 
 	config := new(pipelines.Config)
-	if err := LoadOrDefault(configFilename, config, viper.GetViper()); err != nil {
+	if err := LoadOrDefault(configFilename, config, v); err != nil {
 		return err
 	}
 
@@ -169,8 +176,10 @@ func runImageScan(cmd *cobra.Command, _ []string) error {
 
 func runimagePublish(cmd *cobra.Command, _ []string) error {
 	dryRunEnabled, _ := cmd.Flags().GetBool("dry-run")
-	configFilename, _ := cmd.Flags().GetString("config")
 	cliInterface, _ := cmd.Flags().GetString("cli-interface")
+
+	v := viper.GetViper()
+	configFilename := v.GetString("config")
 
 	config := new(pipelines.Config)
 	if err := LoadOrDefault(configFilename, config, viper.GetViper()); err != nil {
@@ -181,8 +190,10 @@ func runimagePublish(cmd *cobra.Command, _ []string) error {
 
 func runCodeScan(cmd *cobra.Command, _ []string) error {
 	dryRunEnabled, _ := cmd.Flags().GetBool("dry-run")
-	configFilename, _ := cmd.Flags().GetString("config")
 	semgrepExperimental, _ := cmd.Flags().GetBool("semgrep-experimental")
+
+	v := viper.GetViper()
+	configFilename := v.GetString("config")
 
 	config := new(pipelines.Config)
 	if err := LoadOrDefault(configFilename, config, viper.GetViper()); err != nil {

--- a/cmd/workflow-engine/cli/root.go
+++ b/cmd/workflow-engine/cli/root.go
@@ -20,7 +20,7 @@ func NewWorkflowEngineCommand() *cobra.Command {
 	versionCmd := newBasicCommand("version", "print version information", runVersion)
 	cmd := &cobra.Command{
 		Use:              "workflow-engine",
-		Short:            "A portable, opinionate security pipeline",
+		Short:            "A portable, opinionated security pipeline",
 		PersistentPreRun: runCheckLoggingFlags,
 	}
 


### PR DESCRIPTION
 * The image to be used by the action can be explicitly specified with `--image`
 * Additional inputs can be specified and mapped to evironment variables with `--input` (value format: input:VARIABLE:default:Description)
 * There is now a `config_file` input for the generated action